### PR TITLE
3.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-index.*.js
+index.*.*
 package-lock.json
 *.log*
 *.result.css

--- a/.rollup.js
+++ b/.rollup.js
@@ -3,13 +3,16 @@ import babel from 'rollup-plugin-babel';
 export default {
 	input: 'index.js',
 	output: [
-		{ file: 'index.cjs.js', format: 'cjs' },
-		{ file: 'index.es.js', format: 'es' }
+		{ file: 'index.cjs.js', format: 'cjs', sourcemap: true },
+		{ file: 'index.es.mjs', format: 'es', sourcemap: true }
 	],
 	plugins: [
 		babel({
+			plugins: [
+				'@babel/plugin-syntax-dynamic-import'
+			],
 			presets: [
-				['env', { modules: false, targets: { node: 4 } }]
+				['@babel/env', { modules: false, targets: { node: 6 } }]
 			]
 		})
 	]

--- a/.tape.js
+++ b/.tape.js
@@ -29,5 +29,57 @@ module.exports = {
 		'hex': {
 			message: 'supports hex usage'
 		},
+		'import': {
+			message: 'supports { importFrom: "test/import-root.css" } usage',
+			options: {
+				importFrom: 'test/import-root.css'
+			}
+		},
+		'import:array': {
+			message: 'supports { importFrom: ["test/import-root.css"] } usage',
+			options: {
+				importFrom: ['test/import-root.css']
+			},
+			expect: 'import.expect.css',
+			result: 'import.result.css'
+		},
+		'import:array-array': {
+			message: 'supports { importFrom: [["css", "test/import-root.css" ]] } usage',
+			options: {
+				importFrom: [['css', 'test/import-root.css' ]]
+			},
+			expect: 'import.expect.css',
+			result: 'import.result.css'
+		},
+		'import:js': {
+			message: 'supports { importFrom: "test/import-root.js" } usage',
+			options: {
+				importFrom: 'test/import-root.js'
+			},
+			expect: 'import.expect.css',
+			result: 'import.result.css'
+		},
+		'import:json': {
+			message: 'supports { importFrom: "test/import-root.json" } usage',
+			options: {
+				importFrom: 'test/import-root.json'
+			},
+			expect: 'import.expect.css',
+			result: 'import.result.css'
+		},
+		'import:object': {
+			message: 'supports { importFrom: { customProperties: {} } } usage',
+			options: {
+				importFrom: {
+					customProperties: {
+						'--color-blue': 'blue',
+						'--color-red': 'red',
+						'--color': 'var(--color-blue)'
+					}
+				}
+			},
+			expect: 'import.expect.css',
+			result: 'import.result.css'
+		}
 	}
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes to PostCSS color-mod() Function
 
+### 3.0.0 (August 30, 2018)
+
+- Added `importFrom` option which allows you to import Custom Properties from
+CSS, JS, and JSON files, and directly passed objects
+- Fixed an issue where multiple variables could not be used in `color-mod()`
+- Updated to support Node v6+
+
 ### 2.4.3 (July 21, 2018)
 
 - Fixed issue with color-mod not being converted within function

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,170 @@
+# Installing PostCSS color-mod() Function
+
+[PostCSS color-mod() Function] runs in all Node environments, with special instructions for:
+
+| [Node](#node) | [PostCSS CLI](#postcss-cli) | [Webpack](#webpack) | [Create React App](#create-react-app) | [Gulp](#gulp) | [Grunt](#grunt) |
+| --- | --- | --- | --- | --- | --- |
+
+## Node
+
+Add [PostCSS color-mod() Function] to your project:
+
+```bash
+npm install postcss-color-mod-function --save-dev
+```
+
+Use [PostCSS color-mod() Function] to process your CSS:
+
+```js
+const postcssColorMod = require('postcss-color-mod-function');
+
+postcssColorMod.process(YOUR_CSS /*, processOptions, pluginOptions */);
+```
+
+Or use it as a [PostCSS] plugin:
+
+```js
+const postcss = require('postcss');
+const postcssColorMod = require('postcss-color-mod-function');
+
+postcss([
+  postcssColorMod(/* pluginOptions */)
+]).process(YOUR_CSS /*, processOptions */);
+```
+
+## PostCSS CLI
+
+Add [PostCSS CLI] to your project:
+
+```bash
+npm install postcss-cli --save-dev
+```
+
+Use [PostCSS color-mod() Function] in your `postcss.config.js` configuration file:
+
+```js
+const postcssColorMod = require('postcss-color-mod-function');
+
+module.exports = {
+  plugins: [
+    postcssColorMod(/* pluginOptions */)
+  ]
+}
+```
+
+## Webpack
+
+Add [PostCSS Loader] to your project:
+
+```bash
+npm install postcss-loader --save-dev
+```
+
+Use [PostCSS color-mod() Function] in your Webpack configuration:
+
+```js
+const postcssColorMod = require('postcss-color-mod-function');
+
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          'style-loader',
+          { loader: 'css-loader', options: { importLoaders: 1 } },
+          { loader: 'postcss-loader', options: {
+            ident: 'postcss',
+            plugins: () => [
+              postcssColorMod(/* pluginOptions */)
+            ]
+          } }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Create React App
+
+Add [React App Rewired] and [React App Rewire PostCSS] to your project:
+
+```bash
+npm install react-app-rewired react-app-rewire-postcss --save-dev
+```
+
+Use [React App Rewire PostCSS] and [PostCSS color-mod() Function] in your
+`config-overrides.js` file:
+
+```js
+const reactAppRewirePostcss = require('react-app-rewire-postcss');
+const postcssColorMod = require('postcss-color-mod-function');
+
+module.exports = config => reactAppRewirePostcss(config, {
+  plugins: () => [
+    postcssColorMod(/* pluginOptions */)
+  ]
+});
+```
+
+## Gulp
+
+Add [Gulp PostCSS] to your project:
+
+```bash
+npm install gulp-postcss --save-dev
+```
+
+Use [PostCSS color-mod() Function] in your Gulpfile:
+
+```js
+const postcss = require('gulp-postcss');
+const postcssColorMod = require('postcss-color-mod-function');
+
+gulp.task('css', () => gulp.src('./src/*.css').pipe(
+  postcss([
+    postcssColorMod(/* pluginOptions */)
+  ])
+).pipe(
+  gulp.dest('.')
+));
+```
+
+## Grunt
+
+Add [Grunt PostCSS] to your project:
+
+```bash
+npm install grunt-postcss --save-dev
+```
+
+Use [PostCSS color-mod() Function] in your Gruntfile:
+
+```js
+const postcssColorMod = require('postcss-color-mod-function');
+
+grunt.loadNpmTasks('grunt-postcss');
+
+grunt.initConfig({
+  postcss: {
+    options: {
+      use: [
+       postcssColorMod(/* pluginOptions */)
+      ]
+    },
+    dist: {
+      src: '*.css'
+    }
+  }
+});
+```
+
+[Gulp PostCSS]: https://github.com/postcss/gulp-postcss
+[Grunt PostCSS]: https://github.com/nDmitry/grunt-postcss
+[PostCSS]: https://github.com/postcss/postcss
+[PostCSS CLI]: https://github.com/postcss/postcss-cli
+[PostCSS Loader]: https://github.com/postcss/postcss-loader
+[PostCSS color-mod() Function]: https://github.com/jonathantneal/postcss-color-mod-function
+[React App Rewire PostCSS]: https://github.com/csstools/react-app-rewire-postcss
+[React App Rewired]: https://github.com/timarney/react-app-rewired

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 [PostCSS color-mod() Function] lets you modify colors using the `color-mod()`
 function in CSS, following the [CSS Color Module Level 4] specification.
 
-```css
+**`color-mod()` has been removed from the Color Module Level 4 specification.**
+
+```pcss
 :root {
   --brand-red:      color-mod(yellow blend(red 50%));
   --brand-red-hsl:  color-mod(yellow blend(red 50% hsl));
@@ -36,7 +38,7 @@ function in CSS, following the [CSS Color Module Level 4] specification.
 }
 ```
 
-## Supported Colors
+### Supported Colors
 
 The `color-mod()` function accepts `rgb()`, legacy comma-separated `rgb()`,
 `rgba()`, `hsl()`, legacy comma-separated `hsl()`, `hsla()`, `hwb()`, and
@@ -46,7 +48,7 @@ colors without the need for additional plugins.
 Implemention details are available in
 [the specification](https://drafts.csswg.org/css-color/#funcdef-color-mod).
 
-## Supported Color Adjusters
+### Supported Color Adjusters
 
 The `color-mod()` function accepts `red()`, `green()`, `blue()`, `a()` /
 `alpha()`, `rgb()`, `h()` / `hue()`, `s()` / `saturation()`, `l()` /
@@ -56,98 +58,42 @@ The `color-mod()` function accepts `red()`, `green()`, `blue()`, `a()` /
 Implemention details are available in
 [the specification](https://drafts.csswg.org/css-color/#typedef-color-adjuster).
 
-## Supported Variables
+### Supported Variables
 
 By default, `var()` variables will be used if their corresponding Custom
 Properties are found in a `:root` rule, or if a fallback value is specified.
 
----
-
 ## Usage
 
-Add [PostCSS color-mod() Function] to your build tool:
+Add [PostCSS color-mod() Function] to your project:
 
 ```bash
 npm install postcss-color-mod-function --save-dev
 ```
 
-#### Node
-
 Use [PostCSS color-mod() Function] to process your CSS:
 
 ```js
-import postcssColorMod from 'postcss-color-mod-function';
+const postcssColorMod = require('postcss-color-mod-function');
 
-postcssColorMod.process(YOUR_CSS);
+postcssColorMod.process(YOUR_CSS /*, processOptions, pluginOptions */);
 ```
 
-#### PostCSS
-
-Add [PostCSS] to your build tool:
-
-```bash
-npm install postcss --save-dev
-```
-
-Use [PostCSS color-mod() Function] as a plugin:
+Or use it as a [PostCSS] plugin:
 
 ```js
-import postcss from 'postcss';
-import postcssColorMod from 'postcss-color-mod-function';
+const postcss = require('postcss');
+const postcssColorMod = require('postcss-color-mod-function');
 
 postcss([
-  postcssColorMod(/* options */)
-]).process(YOUR_CSS);
+  postcssColorMod(/* pluginOptions */)
+]).process(YOUR_CSS /*, processOptions */);
 ```
 
-#### Gulp
+[PostCSS color-mod() Function] runs in all Node environments, with special instructions for:
 
-Add [Gulp PostCSS] to your build tool:
-
-```bash
-npm install gulp-postcss --save-dev
-```
-
-Use [PostCSS color-mod() Function] in your Gulpfile:
-
-```js
-import postcss from 'gulp-postcss';
-import postcssColorMod from 'postcss-color-mod-function';
-
-gulp.task('css',
-  () => gulp.src('./src/*.css')
-  .pipe( postcss([ postcssColorMod(/* options */) ]) )
-  .pipe( gulp.dest('.') );
-```
-
-#### Grunt
-
-Add [Grunt PostCSS] to your build tool:
-
-```bash
-npm install grunt-postcss --save-dev
-```
-
-Use [PostCSS color-mod() Function] in your Gruntfile:
-
-```js
-import postcssColorMod from 'postcss-color-mod-function';
-
-grunt.loadNpmTasks('grunt-postcss');
-
-grunt.initConfig({
-  postcss: {
-    options: {
-      use: [ postcssColorMod(/* options */) ]
-    },
-    dist: {
-      src: '*.css'
-    }
-  }
-});
-```
-
----
+| [Node](INSTALL.md#node) | [PostCSS CLI](INSTALL.md#postcss-cli) | [Webpack](INSTALL.md#webpack) | [Create React App](INSTALL.md#create-react-app) | [Gulp](INSTALL.md#gulp) | [Grunt](INSTALL.md#grunt) |
+| --- | --- | --- | --- | --- | --- |
 
 ## Options
 
@@ -196,6 +142,54 @@ available in `:root`, or their fallback value if it is specified. By default,
 However, because these transformations occur at build time, they cannot be
 considered accurate. Accurately resolving cascading variables relies on
 knowledge of the living DOM tree.
+
+### importFrom
+
+The `importFrom` option allows you to import variables from other sources,
+which might be CSS, JS, and JSON files, and directly passed objects.
+
+```js
+postcssColorMod({
+  importFrom: 'path/to/file.css' // :root { --brand-dark: blue; --brand-main: var(--brand-dark); }
+});
+```
+
+```pcss
+.brand-faded {
+  color: color-mod(var(--brand-main) a(50%));
+}
+
+/* becomes */
+
+.brand-faded {
+  color: rgba(0, 0, 255, .5);
+}
+```
+
+Multiple files can be passed into this option, and they will be parsed in the
+order they were received. JavaScript files, JSON files, and objects will need
+to namespace custom properties under a `customProperties` or
+`custom-properties` key.
+
+```js
+postcssColorMod({
+  importFrom: [
+    'path/to/file.css',   // :root { --brand-dark: blue; --brand-main: var(--brand-dark); }
+    'and/then/this.js',   // module.exports = { customProperties: { '--brand-dark': 'blue', '--brand-main': 'var(--brand-dark)' } }
+    'and/then/that.json', // { "custom-properties": { "--brand-dark": "blue", "--brand-main": "var(--brand-dark)" } }
+    {
+      customProperties: {
+        '--brand-dark': 'blue',
+        '--brand-main': 'var(--brand-dark)'
+      }
+    }
+  ]
+});
+```
+
+Variables may reference other variables, and this plugin will attempt to
+resolve them. If `transformVars` is set to `false` then `importFrom` will not
+be used.
 
 [cli-img]: https://img.shields.io/travis/jonathantneal/postcss-color-mod-function.svg
 [cli-url]: https://travis-ci.org/jonathantneal/postcss-color-mod-function

--- a/lib/color.js
+++ b/lib/color.js
@@ -323,8 +323,8 @@ function colors2contrast(color1, color2) {
 	// https://drafts.csswg.org/css-color/#contrast-ratio
 	const rgb1 = color2rgb(color1);
 	const rgb2 = color2rgb(color2);
-	var l1 = rgb2luminance(rgb1.red, rgb1.green, rgb1.blue);
-	var l2 = rgb2luminance(rgb2.red, rgb2.green, rgb2.blue);
+	const l1 = rgb2luminance(rgb1.red, rgb1.green, rgb1.blue);
+	const l2 = rgb2luminance(rgb2.red, rgb2.green, rgb2.blue);
 
 	return l1 > l2
 		// if l1 is the relative luminance of the lighter of the colors

--- a/lib/import.js
+++ b/lib/import.js
@@ -1,0 +1,131 @@
+import fs from 'fs';
+import path from 'path';
+import postcss from 'postcss';
+
+/* Import Custom Properties from CSS AST
+/* ========================================================================== */
+
+export function importCustomPropertiesFromCSSAST(root) {
+	// custom properties can be written on html or :root
+	const htmlCustomProperties = {};
+	const rootCustomProperties = {};
+
+	// for each html and :root rule
+	Object(root.nodes).filter(isHtmlOrRootRule).forEach(({ nodes, selector }) => {
+		// for each custom property
+		Object(nodes).filter(isCustomPropertyDecl).forEach(({ prop, value }) => {
+			// write to the custom properties from either html or :root
+			const customProperties = matchHtml.test(selector) ? htmlCustomProperties : rootCustomProperties;
+
+			customProperties[prop] = value;
+		});
+	});
+
+	// return all html and :root custom properties, where :root prevails
+	return Object.assign({}, htmlCustomProperties, rootCustomProperties);
+}
+
+/* Import Custom Properties from CSS File
+/* ========================================================================== */
+
+async function importCustomPropertiesFromCSSFile(from) {
+	const css = await readFile(path.resolve(from));
+	const root = postcss.parse(css, { from: path.resolve(from) });
+
+	return importCustomPropertiesFromCSSAST(root);
+}
+
+/* Import Custom Properties from Object
+/* ========================================================================== */
+
+function importCustomPropertiesFromObject(object) {
+	const customProperties = Object.assign({}, Object(object).customProperties || Object(object)['custom-properties']);
+
+	return customProperties;
+}
+
+/* Import Custom Properties from JSON file
+/* ========================================================================== */
+
+async function importCustomPropertiesFromJSONFile(from) {
+	const object = await readJSON(path.resolve(from));
+
+	return importCustomPropertiesFromObject(object);
+}
+
+/* Import Custom Properties from JS file
+/* ========================================================================== */
+
+async function importCustomPropertiesFromJSFile(from) {
+	const object = await import(path.resolve(from));
+
+	return importCustomPropertiesFromObject(object);
+}
+
+/* Import Custom Properties from Sources
+/* ========================================================================== */
+
+export function importCustomPropertiesFromSources(sources) {
+	return sources.map(source => {
+		if (typeof source === 'string') {
+			if (isCSSPath(source)) {
+				return [ 'css', source ]
+			} else if (isJSPath(source)) {
+				return [ 'js', source ]
+			} else if (isJSONPath(source)) {
+				return [ 'json', source ]
+			}
+		}
+
+		return Object(source);
+	}).reduce(async (customProperties, source) => {
+		const type = source[0];
+		const from = source[1];
+
+		if (type === 'ast') {
+			return Object.assign(customProperties, importCustomPropertiesFromCSSAST(from));
+		}
+
+		if (type === 'css') {
+			return Object.assign(customProperties, await importCustomPropertiesFromCSSFile(from));
+		}
+
+		if (type === 'js') {
+			return Object.assign(customProperties, await importCustomPropertiesFromJSFile(from));
+		}
+
+		if (type === 'json') {
+			return Object.assign(customProperties, await importCustomPropertiesFromJSONFile(from));
+		}
+
+		return Object.assign(customProperties, importCustomPropertiesFromObject(source));
+	}, {});
+}
+
+/* Helper utilities
+/* ========================================================================== */
+
+const matchCustomProperty = /^--\w/;
+const matchHtml = /^html$/i;
+const matchHtmlOrRoot = /^(html|:root)$/i;
+const matchCSSPath = /\.\w*css/i;
+const matchJSPath = /\.\w*js/i;
+const matchJSONPath = /\.\w*json/i;
+
+const isCustomPropertyDecl = node => Object(node).type === 'decl' && matchCustomProperty.test(node.prop);
+const isHtmlOrRootRule = node => Object(node).type === 'rule' && matchHtmlOrRoot.test(node.selector);
+const isCSSPath = from => matchCSSPath.test(from);
+const isJSPath = from => matchJSPath.test(from);
+const isJSONPath = from => matchJSONPath.test(from);
+
+const readFile = from => new Promise((resolve, reject) => {
+	fs.readFile(from, 'utf8', (error, result) => {
+		if (error) {
+			reject(error);
+		} else {
+			resolve(result);
+		}
+	});
+});
+
+const readJSON = async from => JSON.parse(await readFile(from));

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   "module": "index.es.js",
   "files": [
     "index.cjs.js",
-    "index.es.js",
-    "lib"
+    "index.cjs.js.map",
+    "index.es.mjs",
+    "index.es.mjs.map"
   ],
   "scripts": {
     "prepublishOnly": "npm test",
@@ -27,20 +28,21 @@
   },
   "dependencies": {
     "@csstools/convert-colors": "^1.4.0",
-    "postcss": "^6.0.23",
+    "postcss": "^7.0.2",
     "postcss-values-parser": "^1.5.0"
   },
   "devDependencies": {
-    "babel-core": "^6.26.3",
-    "babel-eslint": "^8.2.6",
-    "babel-preset-env": "^1.7.0",
+    "@babel/core": "^7.0.1",
+    "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "babel-eslint": "^9.0.0",
     "echint": "^4.0.1",
-    "eslint": "^5.2.0",
+    "eslint": "^5.6.0",
     "eslint-config-dev": "^2.0.0",
     "postcss-tape": "^2.2.0",
     "pre-commit": "^1.2.2",
-    "rollup": "^0.63.4",
-    "rollup-plugin-babel": "^3.0.7"
+    "rollup": "^0.66.0",
+    "rollup-plugin-babel": "^4.0.3"
   },
   "eslintConfig": {
     "extends": "dev",

--- a/test/basic.colors.expect.css
+++ b/test/basic.colors.expect.css
@@ -121,7 +121,9 @@ test-sameness {
 }
 
 :root {
-	--color: blue;
+	--color-blue: blue;
+	--color-red: red;
+	--color: var(--color-blue);
 }
 
 test-var {
@@ -134,4 +136,8 @@ test-multiple-value-items {
 
 test-linear-gradient {
 	background-image: linear-gradient(rgb(100% 0% 0%), rgb(100% 0% 0% / 0%));
+}
+
+test-var-blend {
+	color: rgb(90% 0% 10%);
 }

--- a/test/basic.css
+++ b/test/basic.css
@@ -121,7 +121,9 @@ test-sameness {
 }
 
 :root {
-	--color: blue;
+	--color-blue: blue;
+	--color-red: red;
+	--color: var(--color-blue);
 }
 
 test-var {
@@ -134,4 +136,8 @@ test-multiple-value-items {
 
 test-linear-gradient {
 	background-image: linear-gradient(color-mod(red alpha(100%)), color-mod(red alpha(0%)));
+}
+
+test-var-blend {
+	color: color-mod(var(--color-red) blend(var(--color) 10%));
 }

--- a/test/basic.expect.css
+++ b/test/basic.expect.css
@@ -121,7 +121,9 @@ test-sameness {
 }
 
 :root {
-	--color: blue;
+	--color-blue: blue;
+	--color-red: red;
+	--color: var(--color-blue);
 }
 
 test-var {
@@ -134,4 +136,8 @@ test-multiple-value-items {
 
 test-linear-gradient {
 	background-image: linear-gradient(rgb(255, 0, 0), rgba(255, 0, 0, 0));
+}
+
+test-var-blend {
+	color: rgb(230, 0, 26);
 }

--- a/test/import-root.css
+++ b/test/import-root.css
@@ -1,0 +1,9 @@
+html {
+	--color-blue: blue;
+	--color-red: red;
+	--color: var(--color-red);
+}
+
+:root {
+	--color: var(--color-blue);
+}

--- a/test/import-root.js
+++ b/test/import-root.js
@@ -1,0 +1,7 @@
+module.exports = {
+	customProperties: {
+		'--color-blue': 'blue',
+		'--color-red': 'red',
+		'--color': 'var(--color-blue)'
+	}
+};

--- a/test/import-root.json
+++ b/test/import-root.json
@@ -1,0 +1,7 @@
+{
+  "custom-properties": {
+    "--color-blue": "blue",
+    "--color-red": "red",
+    "--color": "var(--color-blue)"
+  }
+}

--- a/test/import.css
+++ b/test/import.css
@@ -1,0 +1,95 @@
+test-color-mod {
+	color: color-mod(var(--color));
+	color: color-mod(color-mod(var(--color)));
+	color: color-mod(color-mod(color-mod(var(--color))));
+}
+
+test-red-green-blue-alpha-adjuster {
+	color: color-mod(var(--color) blue(20));
+	color: color-mod(var(--color) blue(20%));
+	color: color-mod(var(--color) green(+ 20));
+	color: color-mod(var(--color) green(+ 20%));
+	color: color-mod(var(--color) red(- 20));
+	color: color-mod(var(--color) red(- 20%));
+	color: color-mod(var(--color) red(- 128));
+	color: color-mod(var(--color) alpha(- 50%));
+	color: color-mod(var(--color) alpha(- .75));
+}
+
+test-rgb-adjuster {
+	color: color-mod(var(--color) rgb(+ 0 255 0));
+	color: color-mod(var(--color) rgb(+ #0f0));
+	color: color-mod(var(--color) rgb(- 60% 0 0));
+	color: color-mod(var(--color) rgb(- #900));
+	color: color-mod(var(--color) rgb(* 1%));
+}
+
+test-hue-adjuster {
+	color: color-mod(var(--color) hue(20));
+	color: color-mod(var(--color) hue(20deg));
+	color: color-mod(var(--color) hue(+ 20));
+	color: color-mod(var(--color) hue(+ 20deg));
+	color: color-mod(var(--color) hue(- 20));
+	color: color-mod(var(--color) hue(- 20deg));
+	color: color-mod(var(--color) hue(* 20));
+	color: color-mod(var(--color) hue(* 20deg));
+}
+
+test-lightness-saturation-adjuster {
+	color: color-mod(var(--color) lightness(50%));
+	color: color-mod(var(--color) lightness(20%));
+	color: color-mod(var(--color) lightness(+ 20%));
+	color: color-mod(var(--color) lightness(- 20%));
+	color: color-mod(var(--color) lightness(* 1.5%));
+	color: color-mod(var(--color) saturation(20%));
+	color: color-mod(var(--color) saturation(+ 20%));
+	color: color-mod(var(--color) saturation(- 20%));
+	color: color-mod(var(--color) saturation(* 1.5%));
+}
+
+test-blackness-whiteness-adjuster {
+	color: color-mod(var(--color) blackness(20%));
+	color: color-mod(var(--color) blackness(+ 20%));
+	color: color-mod(var(--color) blackness(- 1%));
+	color: color-mod(var(--color) blackness(* 20%));
+	color: color-mod(var(--color) whiteness(20%));
+	color: color-mod(var(--color) whiteness(+ 1%));
+	color: color-mod(var(--color) whiteness(- 20%));
+	color: color-mod(var(--color) whiteness(* .5%));
+}
+
+test-tint-shade-adjuster {
+	color: color-mod(var(--color) tint(0%));
+	color: color-mod(var(--color) shade(0%));
+	color: color-mod(var(--color) tint(100%));
+	color: color-mod(var(--color) shade(100%));
+	color: color-mod(var(--color) tint(20%));
+	color: color-mod(var(--color) shade(20%));
+}
+
+test-blend-adjuster {
+	color: color-mod(var(--color) blend(red 50%));
+	color: color-mod(var(--color) blend(red 50% rgb));
+	color: color-mod(var(--color) blend(red 50% hsl));
+	color: color-mod(var(--color) blend(red 50% hwb));
+}
+
+test-contrast-adjuster {
+	color: color-mod(var(--color) contrast(0%));
+	color: color-mod(var(--color) contrast(25%));
+	color: color-mod(var(--color) contrast(50%));
+	color: color-mod(var(--color) contrast(75%));
+	color: color-mod(var(--color) contrast(100%));
+}
+
+test-combination-adjuster {
+	color: color-mod(color-mod(var(--color) blue(10%)) rgb(+ 0 10 0) hue(+ 10deg) tint(10%) lightness(+ 10%) saturation(+ 10%) blend(rebeccapurple 50%));
+}
+
+test-multiple-value-items {
+	border: 1px solid color-mod(var(--color));
+}
+
+test-linear-gradient {
+	background-image: linear-gradient(color-mod(var(--color) alpha(100%)), color-mod(var(--color) alpha(0%)));
+}

--- a/test/import.expect.css
+++ b/test/import.expect.css
@@ -1,0 +1,95 @@
+test-color-mod {
+	color: rgb(0, 0, 255);
+	color: rgb(0, 0, 255);
+	color: rgb(0, 0, 255);
+}
+
+test-red-green-blue-alpha-adjuster {
+	color: rgb(0, 0, 20);
+	color: rgb(0, 0, 51);
+	color: rgb(0, 20, 255);
+	color: rgb(0, 51, 255);
+	color: rgb(0, 0, 255);
+	color: rgb(0, 0, 255);
+	color: rgb(0, 0, 255);
+	color: rgba(0, 0, 255, 0.5);
+	color: rgba(0, 0, 255, 0.25);
+}
+
+test-rgb-adjuster {
+	color: rgb(0, 255, 255);
+	color: rgb(0, 255, 255);
+	color: rgb(0, 0, 255);
+	color: rgb(0, 0, 255);
+	color: rgb(0, 0, 255);
+}
+
+test-hue-adjuster {
+	color: hsl(20, 100%, 50%);
+	color: hsl(20, 100%, 50%);
+	color: hsl(260, 100%, 50%);
+	color: hsl(260, 100%, 50%);
+	color: hsl(220, 100%, 50%);
+	color: hsl(220, 100%, 50%);
+	color: hsl(120, 100%, 50%);
+	color: hsl(120, 100%, 50%);
+}
+
+test-lightness-saturation-adjuster {
+	color: hsl(240, 100%, 50%);
+	color: hsl(240, 100%, 20%);
+	color: hsl(240, 100%, 70%);
+	color: hsl(240, 100%, 30%);
+	color: hsl(240, 100%, 75%);
+	color: hsl(240, 20%, 50%);
+	color: hsl(240, 100%, 50%);
+	color: hsl(240, 80%, 50%);
+	color: hsl(240, 100%, 50%);
+}
+
+test-blackness-whiteness-adjuster {
+	color: rgb(0, 0, 204);
+	color: rgb(0, 0, 204);
+	color: rgb(0, 0, 255);
+	color: rgb(0, 0, 255);
+	color: rgb(51, 51, 255);
+	color: rgb(3, 3, 255);
+	color: rgb(0, 0, 255);
+	color: rgb(0, 0, 255);
+}
+
+test-tint-shade-adjuster {
+	color: rgb(0, 0, 255);
+	color: rgb(0, 0, 255);
+	color: rgb(255, 255, 255);
+	color: rgb(0, 0, 0);
+	color: rgb(51, 51, 255);
+	color: rgb(0, 0, 204);
+}
+
+test-blend-adjuster {
+	color: rgb(128, 0, 128);
+	color: rgb(128, 0, 128);
+	color: hsl(120, 100%, 50%);
+	color: rgb(0, 255, 0);
+}
+
+test-contrast-adjuster {
+	color: rgb(0, 0, 0);
+	color: rgb(0, 0, 64);
+	color: rgb(0, 0, 128);
+	color: rgb(0, 0, 191);
+	color: rgb(0, 0, 255);
+}
+
+test-combination-adjuster {
+	color: rgb(69, 50, 121);
+}
+
+test-multiple-value-items {
+	border: 1px solid rgb(0, 0, 255);
+}
+
+test-linear-gradient {
+	background-image: linear-gradient(rgb(0, 0, 255), rgba(0, 0, 255, 0));
+}


### PR DESCRIPTION
- Added `importFrom` option which allows you to import Custom Properties from CSS, JS, and JSON files, and directly passed objects
- Fixed an issue where multiple variables could not be used in `color-mod()`
- Updated to support Node v6+

Resolves #18, Resolves #20

---

### importFrom

The `importFrom` option allows you to import variables from other sources, which might be CSS, JS, and JSON files, and directly passed objects.

```js
postcssColorMod({
  importFrom: 'path/to/file.css'
});
```

Multiple files can be passed into this option, and they will be parsed in the order they were received. JavaScript files, JSON files, and objects will need to namespace custom properties under a `customProperties` or `custom-properties` key.

```js
postcssColorMod({
  importFrom: [
    'path/to/file.css',
    'and/then/this.js',
    'and/then/that.json',
    {
      customProperties: {
        '--brand-dark': 'blue',
        '--brand-main': 'var(--brand-dark)'
      }
    }
  ]
});
```

Variables may reference other variables, and this plugin will attempt to resolve them. If `transformVars` is set to `false` then `importFrom` will not be used.